### PR TITLE
fixing build with gcc

### DIFF
--- a/tiny-gizmo.hpp
+++ b/tiny-gizmo.hpp
@@ -13,6 +13,7 @@
 #include <functional>   // For std::function callbacks
 #include <memory>       // For std::unique_ptr
 #include <vector>       // For ... 
+#include <ostream>      // For overloads of operator<< to std::ostream& in the operator<< overloads provided by this library
 
 // Visual Studio versions prior to 2015 lack constexpr support
 #if defined(_MSC_VER) && _MSC_VER < 1900 && !defined(constexpr)


### PR DESCRIPTION
MSVC built it as a static lib without problems but GCC needs ```<ostream>``` included before it. Tried with ```<iosfwd>``` but didn't work. Using ```gcc (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 7.1.0``` under windows.

Here are the errors I got before fixing this:

```
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp: In function 'std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)':
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:99: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'char')
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                                                                                 ~~^~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:102: note:   mismatched types 'minalg::vec<T, 2>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/memory:81:0,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:14,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note: candidate: template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__shared_ptr<_Tp, _Lp>&)
     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:102: note:   mismatched types 'const std::__shared_ptr<_Tp, _Lp>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note: candidate: template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:102: note:   mismatched types 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:48:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note: candidate: template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, std::basic_string_view<_CharT, _Traits>)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:102: note:   mismatched types 'std::basic_string_view<_CharT, _Traits>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp: In function 'std::ostream& operator<<(std::ostream&, minalg::vec<T, 3>&)':
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:99: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'char')
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                 ~~^~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:102: note:   mismatched types 'minalg::vec<T, 2>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 3>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:102: note:   mismatched types 'minalg::vec<T, 3>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/memory:81:0,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:14,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note: candidate: template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__shared_ptr<_Tp, _Lp>&)
     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:102: note:   mismatched types 'const std::__shared_ptr<_Tp, _Lp>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note: candidate: template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:102: note:   mismatched types 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:48:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note: candidate: template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, std::basic_string_view<_CharT, _Traits>)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:102: note:   mismatched types 'std::basic_string_view<_CharT, _Traits>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp: In function 'std::ostream& operator<<(std::ostream&, minalg::vec<T, 4>&)':
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:99: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'char')
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                 ~~^~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'minalg::vec<T, 2>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 3>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'minalg::vec<T, 3>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 4>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'minalg::vec<T, 4>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/memory:81:0,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:14,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note: candidate: template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__shared_ptr<_Tp, _Lp>&)
     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'const std::__shared_ptr<_Tp, _Lp>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note: candidate: template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:48:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note: candidate: template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, std::basic_string_view<_CharT, _Traits>)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:102: note:   mismatched types 'std::basic_string_view<_CharT, _Traits>' and 'char'
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                                                                                      ^~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp: In function 'std::ostream& operator<<(std::ostream&, const minalg::mat<T, 3, M>&)':
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:115: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'char')
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                 ~~^~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'minalg::vec<T, 2>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 3>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'minalg::vec<T, 3>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 4>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'minalg::vec<T, 4>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:41: note: candidate: template<class T, int N> std::ostream& operator<<(std::ostream&, const minalg::mat<T, 3, M>&)
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                         ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:41: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'const minalg::mat<T, 3, M>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/memory:81:0,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:14,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note: candidate: template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__shared_ptr<_Tp, _Lp>&)
     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'const std::__shared_ptr<_Tp, _Lp>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note: candidate: template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:48:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note: candidate: template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, std::basic_string_view<_CharT, _Traits>)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:118: note:   mismatched types 'std::basic_string_view<_CharT, _Traits>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp: In function 'std::ostream& operator<<(std::ostream&, const minalg::mat<T, 4, M>&)':
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:115: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'char')
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                 ~~^~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 2>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 2> & b) { return a << '{' << b.x << ", " << b.y << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:413:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'minalg::vec<T, 2>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 3>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 3> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:414:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'minalg::vec<T, 3>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note: candidate: template<class T> std::ostream& operator<<(std::ostream&, minalg::vec<T, 4>&)
 template<class T> std::ostream & operator << (std::ostream & a, minalg::vec<T, 4> & b) { return a << '{' << b.x << ", " << b.y << ", " << b.z << ", " << b.w << '}'; }
                                  ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:415:34: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'minalg::vec<T, 4>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:41: note: candidate: template<class T, int N> std::ostream& operator<<(std::ostream&, const minalg::mat<T, 3, M>&)
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 3, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n'; }
                                         ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:416:41: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'const minalg::mat<T, 3, M>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:41: note: candidate: template<class T, int N> std::ostream& operator<<(std::ostream&, const minalg::mat<T, 4, M>&)
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                         ^~~~~~~~
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:41: note:   template argument deduction/substitution failed:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'const minalg::mat<T, 4, M>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/memory:81:0,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:14,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note: candidate: template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__shared_ptr<_Tp, _Lp>&)
     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/shared_ptr.h:66:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'const std::__shared_ptr<_Tp, _Lp>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note: candidate: template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:6082:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
In file included from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/bits/basic_string.h:48:0,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string:52,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/stdexcept:39,
                 from C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/array:39,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.hpp:11,
                 from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note: candidate: template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(std::basic_ostream<_CharT, _Traits>&, std::basic_string_view<_CharT, _Traits>)
     operator<<(basic_ostream<_CharT, _Traits>& __os,
     ^~~~~~~~
C:/mingw-builds/mingw64/lib/gcc/x86_64-w64-mingw32/7.1.0/include/c++/string_view:558:5: note:   template argument deduction/substitution failed:
In file included from D:\game\third_party\tinygizmo\tiny-gizmo.cpp:4:0:
D:\game\third_party\tinygizmo\tiny-gizmo.hpp:417:118: note:   mismatched types 'std::basic_string_view<_CharT, _Traits>' and 'char'
 template<class T, int N> std::ostream & operator << (std::ostream & a, const minalg::mat<T, 4, N> & b) { return a << '\n' << b.row(0) << '\n' << b.row(1) << '\n' << b.row(2) << '\n' << b.row(3) << '\n'; }
                                                                                                                      ^~~~
mingw32-make[2]: *** [third_party/CMakeFiles/tinygizmo.dir/tinygizmo/tiny-gizmo.cpp.obj] Error 1
mingw32-make[2]: Target 'third_party/CMakeFiles/tinygizmo.dir/build' not remade because of errors.
mingw32-make[1]: *** [third_party/CMakeFiles/tinygizmo.dir/all] Error 2
mingw32-make[1]: Target 'all' not remade because of errors.
mingw32-make: *** [all] Error 2
mingw32-make: Target 'default_target' not remade because of errors.
Traceback (most recent call last):
  File "scripts/python/build.py", line 45, in <module>
  File "C:\Users\onqtam\AppData\Local\Programs\Python\Python36-32\lib\subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['mingw32-make', '--keep-going', '-j8']' returned non-zero exit status 2.
Traceback (most recent call last):
  File "./r", line 43, in <module>
    subprocess.check_call(['python', 'scripts/python/build.py', '-b', args.b, '-c', args.c])
  File "C:\Users\onqtam\AppData\Local\Programs\Python\Python36-32\lib\subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['python', 'scripts/python/build.py', '-b', 'gcc', '-c', 'release']' returned non-zero exit status 1.
```