### PR TITLE
Update gl-api.hpp

### DIFF
--- a/tiny-gizmo-example/gl-api.hpp
+++ b/tiny-gizmo-example/gl-api.hpp
@@ -7,6 +7,7 @@
 #define gl_api_hpp
 
 #include <map>
+#include <cstring>
 #include <string>
 #include <vector>
 #include "linalg.h"


### PR DESCRIPTION
Added cstring header to include std::memcpy for char values. This fixes GCC compilation issue on linux as wel.